### PR TITLE
Fixed first beat detection issue & more

### DIFF
--- a/BeatTimer.cs
+++ b/BeatTimer.cs
@@ -291,7 +291,23 @@ namespace BeatTimer
 
             double selectedbpm = bpmtodel(lower + minindex, samplerate, step);
             double bpm = selectedbpm * 8;
-            return bpm > 400 ? Math.Round(bpm / 2) / 2 : Math.Round(bpm) / 2;
+
+            if (bpm < bpmFloor)
+            {
+                while (bpm < bpmFloor)
+                    bpm *= 2d;
+
+                bpm = Math.Round(bpm);
+            }
+            else if (bpm > bpmCeiling)
+            {
+                bpm = Math.Round(bpm);
+
+                while (bpm > bpmCeiling)
+                    bpm /= 2d;
+            }
+
+            return bpm;
         }
 
 


### PR DESCRIPTION
After the recent update to first beat detection, some of my test songs were thrown off and didn't have the correct whole beat identified. This may be a bug in firstbeatindex() but I'm not sure. I went back to an approach that I was using earlier where I just store intensities in 8 buckets as beats are created (removing the need for a second pass over the array).

In addition, I added a couple of static properties which are populated as processing occurs to get a reasonable approximation of the progress, time-wise, of the processing. This is important since, on devices like Quest, processing can take a very long time.

Finally, I added parameters for bpm floor and ceiling, below which the bpm will be doubled, and above which it will be halved. This is good to have specifically in Audio Trip's case since if we use a BPM that's too high, it becomes impossible to record smooth ribbons since largest chunk of time you can record at is whole beats, and ribbons are controlled by spline control points placed on each beat division. So beats too close together in time/space result in rough-looking ribbons.